### PR TITLE
Remove unnecessary 'Testsuite: autopkgtest' header.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Standards-Version: 3.9.8
 Homepage: https://xen-tools.org/software/xen-tools
 Vcs-Browser: https://github.com/xen-tools/xen-tools
 Vcs-Git: https://github.com/xen-tools/xen-tools.git
-Testsuite: autopkgtest
 
 Package: xen-tools
 Architecture: all


### PR DESCRIPTION
Remove unnecessary 'Testsuite: autopkgtest' header.

Fixes lintian: unncessary-testsuite-autopkgtest-field
